### PR TITLE
fix 1366 insert error

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,3 +36,4 @@ services:
       retries: 10 
     volumes:
       - ./db:/docker-entrypoint-initdb.d
+      - ./my.cnf:/etc/mysql/conf.d/my.cnf

--- a/my.cnf
+++ b/my.cnf
@@ -1,0 +1,7 @@
+[mysql]
+default-character-set=utf8mb4
+
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'


### PR DESCRIPTION
## 概要
#19 に対応しました。

my.cnfファイルを作成し、文字コードをutf8mb4に設定しました。