### PR TITLE
revoke Google access token

### DIFF
--- a/handler/session.go
+++ b/handler/session.go
@@ -98,7 +98,7 @@ func isAuthorizedDomain(email string) bool {
 }
 
 func revokeToken(accessToken string) (resp *http.Response, err error) {
-	googleRevokeURL := "https://accounts.google.com/o/oauth2/revoke"
+	const googleRevokeURL = "https://accounts.google.com/o/oauth2/revoke"
 	u, err := url.Parse(googleRevokeURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## 概要

#10 の修正を行った。

## 内容

トークンをパラメータに含んだリクエストを送信することで、トークンを取り消すことができる。
リクエストを送信するrevokeToken関数を実装した。

```
https://accounts.google.com/o/oauth2/revoke?token={access_token}
```