### PR TITLE
Fix close response

### DIFF
--- a/handler/session.go
+++ b/handler/session.go
@@ -92,7 +92,7 @@ func (u *userHandler) CallbackHandler(c echo.Context) error {
 	}
 	c.SetCookie(cookie)
 
-	return c.Redirect(http.StatusMovedPermanently, "/")
+	return c.Redirect(http.StatusTemporaryRedirect, "/")
 }
 
 func isAuthorizedDomain(email string) bool {

--- a/handler/session.go
+++ b/handler/session.go
@@ -27,7 +27,7 @@ func LoginHandler(c echo.Context) error {
 		return err
 	}
 
-	return c.Redirect(http.StatusMovedPermanently, authURL)
+	return c.Redirect(http.StatusTemporaryRedirect, authURL)
 }
 
 // CallbackHandler -- Provider called this handler after login

--- a/handler/session.go
+++ b/handler/session.go
@@ -58,6 +58,7 @@ func (u *userHandler) CallbackHandler(c echo.Context) error {
 		if err != nil {
 			return err
 		}
+
 		return echo.NewHTTPError(http.StatusUnauthorized, "Please provide valid credentials")
 	}
 
@@ -70,6 +71,7 @@ func (u *userHandler) CallbackHandler(c echo.Context) error {
 		if err != nil {
 			return err
 		}
+
 	}
 
 	data, err := u.userModel.FindByEmail(user.Email())
@@ -103,6 +105,7 @@ func revokeToken(accessToken string) (resp *http.Response, err error) {
 	if err != nil {
 		return nil, err
 	}
+
 	q := u.Query()
 	q.Set("token", accessToken)
 	u.RawQuery = q.Encode()


### PR DESCRIPTION
http.Getの後に、受け取ったresponseをCloseしていなかったことの修正。
それに伴い、関数revokeTokenの返却値をerrのみにした。

また、ファイル内のRedirectのHTTPステータスコードを307に統一した。