### PR TITLE
fix docker-compose network

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 
 services:
   app:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,8 +15,6 @@ services:
       QS_ENV: development
     depends_on:
       - db
-    links:
-      - db
     volumes:
       - ./:/go/src/github.com/Amakuchisan/QuestionStore
 
@@ -28,8 +26,6 @@ services:
       MYSQL_USER: qs
       MYSQL_PASSWORD: qs
       MYSQL_DATABASE: qs
-    expose:
-       - "3306"
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
       timeout: 20s


### PR DESCRIPTION
## 概要

linksは**duplicated**だったため使用するのをやめた。
Docker Composeは、サービスごとに単一のネットワークを作成し、
各コンテナはデフォルトのネットワークに参加する。
コンテナ名によって、各コンテナは名前解決可能である。
